### PR TITLE
fix(nuxt-bridge): add support for nuxt bridge

### DIFF
--- a/lib/templates/plugin.js
+++ b/lib/templates/plugin.js
@@ -28,7 +28,7 @@ export default (ctx, inject) => {
       <% if (typeof options.clientConfigs[key] === 'object') { %>
         <%= key %>ClientConfig = <%= JSON.stringify(options.clientConfigs[key], null, 2) %>
       <% } else if (typeof options.clientConfigs[key] === 'string') { %>
-        <%= key %>ClientConfig = require('<%= options.clientConfigs[key] %>')
+        <%= key %>ClientConfig = import ('<%= options.clientConfigs[key] %>')
 
         if ('default' in <%= key %>ClientConfig) {
           <%= key %>ClientConfig = <%= key %>ClientConfig.default
@@ -113,6 +113,7 @@ export default (ctx, inject) => {
   const apolloProvider = new VueApollo(vueApolloOptions)
   // Allow access to the provider in the context
   app.apolloProvider = apolloProvider
+  inject('theApolloProvider', apolloProvider);
 
   if (process.server) {
     const ApolloSSR = require('vue-apollo/ssr')


### PR DESCRIPTION
Nuxt Bridge exposes the Nuxt 2 context via nuxtApp.nuxt2Context.

However, when doing `app.apolloProvider`, the apolloProvider is not added to this context.

In order to get the apolloProvider onto this nuxt2Context, we must use inject().

However, it requires a different name than "apolloProvider" when injecting, or we get errors.